### PR TITLE
fix: remove tls client config used in server initialization

### DIFF
--- a/internal/app/pdns-api-proxy/internalserviceproxy/internalserviceproxy.go
+++ b/internal/app/pdns-api-proxy/internalserviceproxy/internalserviceproxy.go
@@ -1,7 +1,6 @@
 package internalserviceproxy
 
 import (
-	"crypto/tls"
 	"net/http"
 	"time"
 
@@ -59,11 +58,8 @@ func startHTTPServer(serviceconfig *config.ServiceConfiguration) error {
 	}
 
 	server := &http.Server{
-		Addr:    serviceaddress,
-		Handler: router,
-		TLSConfig: &tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec
-		},
+		Addr:         serviceaddress,
+		Handler:      router,
 		ReadTimeout:  serverreadtimeout,
 		WriteTimeout: serverwritetimeout,
 	}


### PR DESCRIPTION
This MR removes a tls client config used in server initialization.