### PR TITLE
ci: make linter happy

### DIFF
--- a/cmd/example-microservice/main.go
+++ b/cmd/example-microservice/main.go
@@ -79,7 +79,13 @@ func startHealthServiceEndpoint(xd msframe.Microservice) {
 		log.Fatal(err2)
 	}
 
-	err := http.ListenAndServe(sdurl.Host, nil)
+	server := http.Server{
+		Addr:              sdurl.Host,
+		ReadHeaderTimeout: 42,
+		Handler:           nil,
+	}
+
+	err := server.ListenAndServe()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/app/pdns-api-proxy/internalserviceproxy/httphandler.go
+++ b/internal/app/pdns-api-proxy/internalserviceproxy/httphandler.go
@@ -2,7 +2,6 @@ package internalserviceproxy
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 
@@ -100,7 +99,7 @@ func defaultProxy(respond http.ResponseWriter, incomingrequest *http.Request) {
 		proxyurl += "?" + incomingrequest.URL.RawQuery
 	}
 
-	proxyrequest, preparerequesterr := http.NewRequestWithContext(context.Background(), incomingrequest.Method, proxyurl, incomingbodyreader)
+	proxyrequest, preparerequesterr := http.NewRequestWithContext(incomingrequest.Context(), incomingrequest.Method, proxyurl, incomingbodyreader)
 	if preparerequesterr != nil {
 		logger.ErrorErrLog(preparerequesterr)
 	}


### PR DESCRIPTION
Ensure that golangci-lint doesn't report errors.